### PR TITLE
PointsAbove and PointsBellow aggregations

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterPointsKThresholdStrategy.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/FilterPointsKThresholdStrategy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.metric.*;
+import lombok.Data;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
+
+@Data
+public class FilterPointsKThresholdStrategy implements MetricMappingStrategy{
+    private final FilterKThresholdType filterType;
+    private final double k;
+
+    @Override
+    public MetricCollection apply(MetricCollection metrics) {
+        return MetricCollection.build(
+            MetricType.POINT,
+            filterWithThreshold(metrics.getDataAs(Point.class))
+        );
+    }
+
+    private List<Point> filterWithThreshold(List<Point> points) {
+        return points.stream().filter(point -> filterType.predicate(point.getValue(), k)).collect(toList());
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MetricMappingAggregation.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MetricMappingAggregation.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.*;
+import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.metric.*;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
+
+@Data
+public abstract class MetricMappingAggregation implements AggregationInstance {
+    private final MetricMappingStrategy metricMappingStrategy;
+
+    @Override
+    public long estimate(DateRange range) {
+        return -1;
+    }
+
+    @Override
+    public long cadence() {
+        return 0;
+    }
+
+    @Override
+    public AggregationSession session(DateRange range) {
+        return new Session(EmptyInstance.INSTANCE.session(range));
+    }
+
+    @Override
+    public AggregationInstance distributed() {
+        return EmptyInstance.INSTANCE;
+    }
+
+    class Session implements AggregationSession {
+
+        private final AggregationSession childSession;
+
+        public Session(AggregationSession childSession) {
+            this.childSession = childSession;
+        }
+
+        @Override
+        public void updatePoints(
+            final Map<String, String> key, final Set<Series> series, final List<Point> values
+        ) {
+            this.childSession.updatePoints(key, series, values);
+        }
+
+        @Override
+        public void updateEvents(
+            final Map<String, String> key, final Set<Series> series, final List<Event> values
+        ) {
+            this.childSession.updateEvents(key, series, values);
+        }
+
+        @Override
+        public void updatePayload(
+            final Map<String, String> key, final Set<Series> series, final List<Payload> values
+        ) {
+            this.childSession.updatePayload(key, series, values);
+        }
+
+        @Override
+        public void updateGroup(
+            final Map<String, String> key, final Set<Series> series, final List<MetricGroup> values
+        ) {
+            this.childSession.updateGroup(key, series, values);
+        }
+
+        @Override
+        public void updateSpreads(
+            final Map<String, String> key, final Set<Series> series, final List<com.spotify.heroic.metric.Spread> values
+        ) {
+            this.childSession.updateSpreads(key, series, values);
+        }
+
+        @Override
+        public AggregationResult result() {
+            AggregationResult aggregationResult = this.childSession.result();
+            List<AggregationOutput> outputs = aggregationResult
+                .getResult()
+                .stream()
+                .map(aggregationOutput -> new AggregationOutput(
+                    aggregationOutput.getKey(),
+                    aggregationOutput.getSeries(),
+                    metricMappingStrategy.apply(aggregationOutput.getMetrics())
+                ))
+                .collect(toList());
+            return new AggregationResult(outputs, aggregationResult.getStatistics());
+        }
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MetricMappingStrategy.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MetricMappingStrategy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.metric.MetricCollection;
+
+public interface MetricMappingStrategy {
+    MetricCollection apply(MetricCollection metrics);
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Module.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Module.java
@@ -126,6 +126,12 @@ public class Module implements HeroicModule {
             c.register(BelowK.NAME, BelowK.class, BelowKInstance.class,
                 args -> new BelowK(fetchK(args, DoubleExpression.class).getValue(),
                     Optional.empty()));
+
+            c.register(PointsAboveK.NAME, PointsAboveK.class, PointsAboveKInstance.class,
+                args -> new PointsAboveK(fetchK(args, DoubleExpression.class).getValue()));
+
+            c.register(PointsBelowK.NAME, PointsBelowK.class, PointsBelowKInstance.class,
+                args -> new PointsBelowK(fetchK(args, DoubleExpression.class).getValue()));
         }
 
         private <T extends Expression> T fetchK(AggregationArguments args, Class<T> doubleClass) {

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsAboveK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsAboveK.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationContext;
+import com.spotify.heroic.aggregation.AggregationInstance;
+import lombok.Data;
+
+import java.beans.ConstructorProperties;
+
+@Data
+public class PointsAboveK implements Aggregation {
+    public static final String NAME = "pointsabove";
+    private final double k;
+
+    @ConstructorProperties({"k"})
+    public PointsAboveK(final double k) {
+        this.k = k;
+    }
+    @Override
+    public AggregationInstance apply(AggregationContext aggregationContext) {
+        return new PointsAboveKInstance(k);
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsAboveKInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsAboveKInstance.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.heroic.aggregation.simple;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.beans.ConstructorProperties;
+
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class PointsAboveKInstance extends MetricMappingAggregation{
+
+    @ConstructorProperties({"k"})
+    public PointsAboveKInstance(double k) {
+        super(new FilterPointsKThresholdStrategy(FilterKThresholdType.ABOVE, k));
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsBelowK.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsBelowK.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationContext;
+import com.spotify.heroic.aggregation.AggregationInstance;
+import lombok.Data;
+
+import java.beans.ConstructorProperties;
+
+@Data
+public class PointsBelowK implements Aggregation {
+    public static final String NAME = "pointsbelow";
+    private final double k;
+
+    @ConstructorProperties({"k"})
+    public PointsBelowK(final double k) {
+        this.k = k;
+    }
+    @Override
+    public AggregationInstance apply(AggregationContext aggregationContext) {
+        return new PointsBelowKInstance(k);
+    }
+}

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsBelowKInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsBelowKInstance.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.heroic.aggregation.simple;
+
+import java.beans.ConstructorProperties;
+
+public class PointsBelowKInstance extends MetricMappingAggregation{
+
+    @ConstructorProperties({"k"})
+    public PointsBelowKInstance(double k) {
+        super(new FilterPointsKThresholdStrategy(FilterKThresholdType.BELOW, k));
+    }
+}

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/FilterPointsKThresholdStrategyTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/FilterPointsKThresholdStrategyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.heroic.aggregation.simple;
+
+import com.spotify.heroic.metric.MetricCollection;
+import com.spotify.heroic.metric.MetricType;
+import com.spotify.heroic.metric.Point;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+import static junit.framework.TestCase.assertFalse;
+
+public class FilterPointsKThresholdStrategyTest {
+    private static final int POINT_RANGE_START = 0;
+    private static final int TEST_THRESHOLD = 38;
+    private static final int POINT_RANGE_END = 100;
+
+    private MetricCollection initialMetrics;
+
+    @Before
+    public void setUp() throws Exception {
+        initialMetrics = MetricCollection.build(MetricType.POINT, pointsRange());
+    }
+
+    @Test
+    public void testFilterPointsAbove() throws Exception {
+        FilterPointsKThresholdStrategy strategy = new FilterPointsKThresholdStrategy(FilterKThresholdType.ABOVE, TEST_THRESHOLD);
+        List<Point> result = strategy.apply(initialMetrics).getDataAs(Point.class);
+        assertFalse(result.stream().map(Point::getValue).anyMatch(v -> v <= TEST_THRESHOLD));
+    }
+
+    @Test
+    public void testFilterPointsBelow() throws Exception {
+        FilterPointsKThresholdStrategy strategy = new FilterPointsKThresholdStrategy(FilterKThresholdType.BELOW, TEST_THRESHOLD);
+        List<Point> result = strategy.apply(initialMetrics).getDataAs(Point.class);
+        assertFalse(result.stream().map(Point::getValue).anyMatch(v -> v >= TEST_THRESHOLD));
+    }
+
+    private List<Point> pointsRange() {
+        return IntStream.range(POINT_RANGE_START, POINT_RANGE_END).mapToObj(i -> new Point(i, i)).collect(toList());
+    }
+}

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/PointsAboveKInstanceTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/PointsAboveKInstanceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.heroic.aggregation.simple;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.spotify.heroic.aggregation.*;
+import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.metric.Point;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
+
+public class PointsAboveKInstanceTest {
+
+    @Test
+    public void testFilterPointsAboveKSession() {
+        final GroupingAggregation g1 =
+            new GroupInstance(Optional.of(ImmutableList.of("site")), EmptyInstance.INSTANCE);
+
+        final AggregationInstance a1 = ChainInstance.of(g1, new PointsAboveKInstance(1));
+
+        final Set<Series> states = new HashSet<>();
+
+        final Series s1 = Series.of("foo", ImmutableMap.of("site", "sto", "host", "a"));
+        final Series s2 = Series.of("foo", ImmutableMap.of("site", "ash", "host", "b"));
+        final Series s3 = Series.of("foo", ImmutableMap.of("site", "lon", "host", "c"));
+
+        states.add(s1);
+        states.add(s2);
+        states.add(s3);
+
+        final AggregationSession session = a1.session(new DateRange(0, 10000));
+
+        session.updatePoints(s1.getTags(), ImmutableSet.of(s1),
+            ImmutableList.of(new Point(2, 2.0), new Point(3, 2.0)));
+        session.updatePoints(s2.getTags(), ImmutableSet.of(s2),
+            ImmutableList.of(new Point(2, 3.0), new Point(3, 3.0)));
+        session.updatePoints(s3.getTags(), ImmutableSet.of(s3),
+            ImmutableList.of(new Point(2, 1.0), new Point(3, 1.0)));
+
+        final List<AggregationOutput> result = session.result().getResult();
+
+        assertSeries(3, result);
+        assertPoints(1, 4, result);
+    }
+
+
+    private void assertSeries(int series, List<AggregationOutput> result) {
+        assertEquals(series, result.size());
+    }
+
+    private void assertPoints(int k, int expected, List<AggregationOutput> result) {
+        assertFalse(result.stream().flatMap( s -> s.getMetrics().getDataAs(Point.class).stream()).map(Point::getValue).anyMatch(v -> v <= k));
+        assertEquals(expected, result.stream().flatMap(s -> s.getMetrics().getDataAs(Point.class).stream()).count());
+    }
+
+
+}

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/PointsBelowKInstanceTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/PointsBelowKInstanceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.heroic.aggregation.simple;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.spotify.heroic.aggregation.*;
+import com.spotify.heroic.common.DateRange;
+import com.spotify.heroic.common.Series;
+import com.spotify.heroic.metric.Point;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
+
+public class PointsBelowKInstanceTest {
+    @Test
+    public void testFilterPointsAboveKSession() {
+        final GroupingAggregation g1 =
+            new GroupInstance(Optional.of(ImmutableList.of("site")), EmptyInstance.INSTANCE);
+
+        final AggregationInstance a1 = ChainInstance.of(g1, new PointsBelowKInstance(2));
+
+        final Set<Series> states = new HashSet<>();
+
+        final Series s1 = Series.of("foo", ImmutableMap.of("site", "sto", "host", "a"));
+        final Series s2 = Series.of("foo", ImmutableMap.of("site", "ash", "host", "b"));
+        final Series s3 = Series.of("foo", ImmutableMap.of("site", "lon", "host", "c"));
+
+        states.add(s1);
+        states.add(s2);
+        states.add(s3);
+
+        final AggregationSession session = a1.session(new DateRange(0, 10000));
+
+        session.updatePoints(s1.getTags(), ImmutableSet.of(s1),
+            ImmutableList.of(new Point(2, 2.0), new Point(3, 2.0)));
+        session.updatePoints(s2.getTags(), ImmutableSet.of(s2),
+            ImmutableList.of(new Point(2, 3.0), new Point(3, 3.0)));
+        session.updatePoints(s3.getTags(), ImmutableSet.of(s3),
+            ImmutableList.of(new Point(2, 1.0), new Point(3, 1.0)));
+
+        final List<AggregationOutput> result = session.result().getResult();
+
+        assertSeries(3, result);
+        assertPoints(2, 2, result);
+    }
+
+
+    private void assertSeries(int series, List<AggregationOutput> result) {
+        assertEquals(series, result.size());
+    }
+
+    private void assertPoints(int k, int expected, List<AggregationOutput> result) {
+        assertFalse(result.stream().flatMap( s -> s.getMetrics().getDataAs(Point.class).stream()).map(Point::getValue).anyMatch(v -> v >= k));
+        assertEquals(expected, result.stream().flatMap(s -> s.getMetrics().getDataAs(Point.class).stream()).count());
+    }
+}


### PR DESCRIPTION
This pull request creates 2 additional aggregations

1. PointsAbove aggregation removes all points from a selected series which are less or equal specified number k.

2. PointsBellow aggregation removes all points from a selected series which are greater or equal specified number k.