### PR TITLE
Remove k from variables and classes. Skip flter for non point metrics.

### DIFF
--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MetricMappingAggregation.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/MetricMappingAggregation.java
@@ -21,10 +21,17 @@
 
 package com.spotify.heroic.aggregation.simple;
 
-import com.spotify.heroic.aggregation.*;
+import com.spotify.heroic.aggregation.AggregationInstance;
+import com.spotify.heroic.aggregation.AggregationResult;
+import com.spotify.heroic.aggregation.AggregationSession;
+import com.spotify.heroic.aggregation.EmptyInstance;
+import com.spotify.heroic.aggregation.AggregationOutput;
 import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Series;
-import com.spotify.heroic.metric.*;
+import com.spotify.heroic.metric.Event;
+import com.spotify.heroic.metric.MetricGroup;
+import com.spotify.heroic.metric.Payload;
+import com.spotify.heroic.metric.Point;
 import lombok.Data;
 
 import java.util.List;
@@ -95,7 +102,8 @@ public abstract class MetricMappingAggregation implements AggregationInstance {
 
         @Override
         public void updateSpreads(
-            final Map<String, String> key, final Set<Series> series, final List<com.spotify.heroic.metric.Spread> values
+            final Map<String, String> key, final Set<Series> series,
+            final List<com.spotify.heroic.metric.Spread> values
         ) {
             this.childSession.updateSpreads(key, series, values);
         }

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Module.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/Module.java
@@ -127,11 +127,11 @@ public class Module implements HeroicModule {
                 args -> new BelowK(fetchK(args, DoubleExpression.class).getValue(),
                     Optional.empty()));
 
-            c.register(PointsAboveK.NAME, PointsAboveK.class, PointsAboveKInstance.class,
-                args -> new PointsAboveK(fetchK(args, DoubleExpression.class).getValue()));
+            c.register(PointsAbove.NAME, PointsAbove.class, PointsAboveInstance.class,
+                args -> new PointsAbove(fetchK(args, DoubleExpression.class).getValue()));
 
-            c.register(PointsBelowK.NAME, PointsBelowK.class, PointsBelowKInstance.class,
-                args -> new PointsBelowK(fetchK(args, DoubleExpression.class).getValue()));
+            c.register(PointsBelow.NAME, PointsBelow.class, PointsBelowInstance.class,
+                args -> new PointsBelow(fetchK(args, DoubleExpression.class).getValue()));
         }
 
         private <T extends Expression> T fetchK(AggregationArguments args, Class<T> doubleClass) {

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsAbove.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsAbove.java
@@ -18,19 +18,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package com.spotify.heroic.aggregation.simple;
 
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationContext;
+import com.spotify.heroic.aggregation.AggregationInstance;
+import lombok.Data;
 
 import java.beans.ConstructorProperties;
 
-@ToString
-@EqualsAndHashCode(callSuper = true)
-public class PointsAboveKInstance extends MetricMappingAggregation{
+@Data
+public class PointsAbove implements Aggregation {
+    public static final String NAME = "pointsabove";
+    private final double threshold;
 
-    @ConstructorProperties({"k"})
-    public PointsAboveKInstance(double k) {
-        super(new FilterPointsKThresholdStrategy(FilterKThresholdType.ABOVE, k));
+    @ConstructorProperties({"threshold"})
+    public PointsAbove(final double threshold) {
+        this.threshold = threshold;
+    }
+    @Override
+    public AggregationInstance apply(AggregationContext aggregationContext) {
+        return new PointsAboveInstance(threshold);
     }
 }

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsAboveInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsAboveInstance.java
@@ -18,26 +18,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package com.spotify.heroic.aggregation.simple;
 
-import com.spotify.heroic.aggregation.Aggregation;
-import com.spotify.heroic.aggregation.AggregationContext;
-import com.spotify.heroic.aggregation.AggregationInstance;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.beans.ConstructorProperties;
 
-@Data
-public class PointsBelowK implements Aggregation {
-    public static final String NAME = "pointsbelow";
-    private final double k;
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class PointsAboveInstance extends MetricMappingAggregation {
 
-    @ConstructorProperties({"k"})
-    public PointsBelowK(final double k) {
-        this.k = k;
-    }
-    @Override
-    public AggregationInstance apply(AggregationContext aggregationContext) {
-        return new PointsBelowKInstance(k);
+    @ConstructorProperties({"threshold"})
+    public PointsAboveInstance(double threshold) {
+        super(new FilterPointsThresholdStrategy(FilterKThresholdType.ABOVE, threshold));
     }
 }

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsBelow.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsBelow.java
@@ -21,27 +21,24 @@
 
 package com.spotify.heroic.aggregation.simple;
 
-import com.spotify.heroic.metric.*;
+import com.spotify.heroic.aggregation.Aggregation;
+import com.spotify.heroic.aggregation.AggregationContext;
+import com.spotify.heroic.aggregation.AggregationInstance;
 import lombok.Data;
 
-import java.util.*;
-
-import static java.util.stream.Collectors.toList;
+import java.beans.ConstructorProperties;
 
 @Data
-public class FilterPointsKThresholdStrategy implements MetricMappingStrategy{
-    private final FilterKThresholdType filterType;
-    private final double k;
+public class PointsBelow implements Aggregation {
+    public static final String NAME = "pointsbelow";
+    private final double threshold;
 
-    @Override
-    public MetricCollection apply(MetricCollection metrics) {
-        return MetricCollection.build(
-            MetricType.POINT,
-            filterWithThreshold(metrics.getDataAs(Point.class))
-        );
+    @ConstructorProperties({"threshold"})
+    public PointsBelow(final double threshold) {
+        this.threshold = threshold;
     }
-
-    private List<Point> filterWithThreshold(List<Point> points) {
-        return points.stream().filter(point -> filterType.predicate(point.getValue(), k)).collect(toList());
+    @Override
+    public AggregationInstance apply(AggregationContext aggregationContext) {
+        return new PointsBelowInstance(threshold);
     }
 }

--- a/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsBelowInstance.java
+++ b/aggregation/simple/src/main/java/com/spotify/heroic/aggregation/simple/PointsBelowInstance.java
@@ -18,14 +18,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package com.spotify.heroic.aggregation.simple;
 
 import java.beans.ConstructorProperties;
 
-public class PointsBelowKInstance extends MetricMappingAggregation{
+public class PointsBelowInstance extends MetricMappingAggregation {
 
-    @ConstructorProperties({"k"})
-    public PointsBelowKInstance(double k) {
-        super(new FilterPointsKThresholdStrategy(FilterKThresholdType.BELOW, k));
+    @ConstructorProperties({"threshold"})
+    public PointsBelowInstance(double threshold) {
+        super(new FilterPointsThresholdStrategy(FilterKThresholdType.BELOW, threshold));
     }
 }

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/FilterPointsThresholdStrategyTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/FilterPointsThresholdStrategyTest.java
@@ -20,6 +20,7 @@
  */
 package com.spotify.heroic.aggregation.simple;
 
+import com.spotify.heroic.metric.Event;
 import com.spotify.heroic.metric.MetricCollection;
 import com.spotify.heroic.metric.MetricType;
 import com.spotify.heroic.metric.Point;
@@ -31,8 +32,9 @@ import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.toList;
 import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
 
-public class FilterPointsKThresholdStrategyTest {
+public class FilterPointsThresholdStrategyTest {
     private static final int POINT_RANGE_START = 0;
     private static final int TEST_THRESHOLD = 38;
     private static final int POINT_RANGE_END = 100;
@@ -46,19 +48,31 @@ public class FilterPointsKThresholdStrategyTest {
 
     @Test
     public void testFilterPointsAbove() throws Exception {
-        FilterPointsKThresholdStrategy strategy = new FilterPointsKThresholdStrategy(FilterKThresholdType.ABOVE, TEST_THRESHOLD);
+        FilterPointsThresholdStrategy strategy = new FilterPointsThresholdStrategy(FilterKThresholdType.ABOVE, TEST_THRESHOLD);
         List<Point> result = strategy.apply(initialMetrics).getDataAs(Point.class);
         assertFalse(result.stream().map(Point::getValue).anyMatch(v -> v <= TEST_THRESHOLD));
     }
 
     @Test
     public void testFilterPointsBelow() throws Exception {
-        FilterPointsKThresholdStrategy strategy = new FilterPointsKThresholdStrategy(FilterKThresholdType.BELOW, TEST_THRESHOLD);
+        FilterPointsThresholdStrategy strategy = new FilterPointsThresholdStrategy(FilterKThresholdType.BELOW, TEST_THRESHOLD);
         List<Point> result = strategy.apply(initialMetrics).getDataAs(Point.class);
         assertFalse(result.stream().map(Point::getValue).anyMatch(v -> v >= TEST_THRESHOLD));
     }
 
+    @Test
+    public void testFilterDataIsDifferentFromPointsThenCollectionIsNotProcessed() throws Exception {
+        FilterPointsThresholdStrategy strategy = new FilterPointsThresholdStrategy(FilterKThresholdType.BELOW, TEST_THRESHOLD);
+        MetricCollection eventsCollection = MetricCollection.events(eventsRange());
+        MetricCollection result = strategy.apply(eventsCollection);
+        assertEquals(eventsCollection, result);
+    }
+
     private List<Point> pointsRange() {
         return IntStream.range(POINT_RANGE_START, POINT_RANGE_END).mapToObj(i -> new Point(i, i)).collect(toList());
+    }
+
+    private List<Event> eventsRange() {
+        return IntStream.range(POINT_RANGE_START, POINT_RANGE_END).mapToObj(Event::new).collect(toList());
     }
 }

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/PointsAboveInstanceTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/PointsAboveInstanceTest.java
@@ -37,14 +37,14 @@ import java.util.Set;
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 
-public class PointsAboveKInstanceTest {
+public class PointsAboveInstanceTest {
 
     @Test
     public void testFilterPointsAboveKSession() {
         final GroupingAggregation g1 =
             new GroupInstance(Optional.of(ImmutableList.of("site")), EmptyInstance.INSTANCE);
 
-        final AggregationInstance a1 = ChainInstance.of(g1, new PointsAboveKInstance(1));
+        final AggregationInstance a1 = ChainInstance.of(g1, new PointsAboveInstance(1));
 
         final Set<Series> states = new HashSet<>();
 

--- a/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/PointsBelowInstanceTest.java
+++ b/aggregation/simple/src/test/java/com/spotify/heroic/aggregation/simple/PointsBelowInstanceTest.java
@@ -37,13 +37,13 @@ import java.util.Set;
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 
-public class PointsBelowKInstanceTest {
+public class PointsBelowInstanceTest {
     @Test
     public void testFilterPointsAboveKSession() {
         final GroupingAggregation g1 =
             new GroupInstance(Optional.of(ImmutableList.of("site")), EmptyInstance.INSTANCE);
 
-        final AggregationInstance a1 = ChainInstance.of(g1, new PointsBelowKInstance(2));
+        final AggregationInstance a1 = ChainInstance.of(g1, new PointsBelowInstance(2));
 
         final Set<Series> states = new HashSet<>();
 


### PR DESCRIPTION
- Added condition for non profit metrics
- K is removed from class and variables name
- Variables and params are renamed to threshold. This name seems to be more self explanatory then count/value. But I can change it to value if you like it better. 